### PR TITLE
Add redux

### DIFF
--- a/webapp/backend/lightchanger/views.py
+++ b/webapp/backend/lightchanger/views.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from functools import wraps
 import json, requests
 
-from lights.lights.animations import NAME_TO_ANIMATION
+from lights.animations import NAME_TO_ANIMATION
 
 
 def is_request_authenticated(request):

--- a/webapp/backend/lightchanger/views.py
+++ b/webapp/backend/lightchanger/views.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from functools import wraps
 import json, requests
 
-from lights.animations import NAME_TO_ANIMATION
+from lights.lights.animations import NAME_TO_ANIMATION
 
 
 def is_request_authenticated(request):
@@ -75,9 +75,9 @@ class LightOptionsView(viewsets.ModelViewSet):
     @basic_authentication
     def reset_parameters(self, request, *args, **kwargs):
       light_pattern_json = request.data
-      light_pattern_name = light_pattern_json['light_pattern_name']
       light_pattern_id = light_pattern_json['light_pattern_id']
       existing = LightPatternOption.objects.get(pk=light_pattern_id)
+      light_pattern_name = existing.animation_id
       
       animation = NAME_TO_ANIMATION[light_pattern_name]
 
@@ -92,10 +92,10 @@ class LightOptionsView(viewsets.ModelViewSet):
     @basic_authentication
     def update_parameters(self, request, *args, **kwargs):
       light_pattern_json = request.data
-      light_pattern_name = light_pattern_json['light_pattern_name']
       light_pattern_id = light_pattern_json['light_pattern_id']
       new_parameters = light_pattern_json['parameters']
       existing = LightPatternOption.objects.get(pk=light_pattern_id)
+      light_pattern_name = existing.animation_id
       
       animation = NAME_TO_ANIMATION[light_pattern_name]
 
@@ -149,8 +149,8 @@ class LightPatternsView(viewsets.ModelViewSet):
     def updatepi(self, request, *args, **kwargs):
         request_data = request.data.copy()
         light_pattern_id = request_data['light_pattern_id']
-        light_pattern_name = request_data['light_pattern_name']
         light_pattern = LightPatternOption.objects.get(pk=light_pattern_id)
+        light_pattern_name = light_pattern.animation_id
 
         animation = NAME_TO_ANIMATION[light_pattern_name]
         parameters = animation.deserialize_parameters(light_pattern.parameters_json)

--- a/webapp/frontend/package-lock.json
+++ b/webapp/frontend/package-lock.json
@@ -8,10 +8,11 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "axios": "^1.6.7",
+        "@reduxjs/toolkit": "^2.1.0",
         "next": "14.1.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-redux": "^9.1.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -434,6 +435,29 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.1.0.tgz",
+      "integrity": "sha512-nfJ/b4ZhzUevQ1ZPKjlDL6CMYxO4o7ZL7OSsvSOxzT/EN11LsBDgTqP7aedHtBrFSVoK7oTP1SbMWUwGb30NLg==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz",
@@ -467,13 +491,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.52",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.52.tgz",
       "integrity": "sha512-E/YjWh3tH+qsLKaUzgpZb5AY0ChVa+ZJzF7ogehVILrFpdQk6nC/WXOv0bfFEABbXbgNxLBGU7IIZByPKb6eBw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -493,7 +517,12 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.20.0",
@@ -877,11 +906,6 @@
         "has-symbols": "^1.0.3"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.17",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
@@ -938,16 +962,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1168,17 +1182,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1224,7 +1227,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -1284,14 +1287,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -2040,25 +2035,6 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2082,19 +2058,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -2432,6 +2395,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -3058,25 +3030,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3697,11 +3650,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3760,6 +3708,32 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-redux": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "react-native": ">=0.69",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3779,6 +3753,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -3823,6 +3810,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -4635,6 +4627,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/webapp/frontend/package-lock.json
+++ b/webapp/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.1.0",
+        "axios": "^1.6.7",
         "next": "14.1.0",
         "react": "^18",
         "react-dom": "^18",
@@ -906,6 +907,11 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.17",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
@@ -962,6 +968,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1182,6 +1198,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1287,6 +1314,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -2035,6 +2070,25 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2058,6 +2112,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3030,6 +3097,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3649,6 +3735,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.1.0",
+    "axios": "^1.6.7",
     "next": "14.1.0",
     "react": "^18",
     "react-dom": "^18",

--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -9,10 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "axios": "^1.6.7",
+    "@reduxjs/toolkit": "^2.1.0",
     "next": "14.1.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-redux": "^9.1.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/webapp/frontend/src/app/AnimationCard.tsx
+++ b/webapp/frontend/src/app/AnimationCard.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { useState } from 'react';
-import { useBackend } from '@/hooks/backend';
+import { selectAnimation } from '@/reducers/rootReducer';
+import { useAppDispatch } from '@/hooks/hooks';
 
 const AnimationCard = (props: any) => {
-  const {selectAnimation, updateParameters, resetParameters} = useBackend();
+  const dispatch = useAppDispatch();
   const [editing, setEditing] = useState(false);
   const [cardClickAnimation, setCardClickAnimation] = useState(false);
   const [parameters, setParameters] = useState(props.params);
@@ -19,12 +20,12 @@ const AnimationCard = (props: any) => {
   const handleParameterEdit = (e: any) => {
     e.preventDefault();
     setEditing(false);
-    updateParameters(props.light_id, parameters);
+    // updateParameters(props.light_id, parameters);
   };
 
   const handleResetButtonClick = (e: any) => {
     e.stopPropagation();
-    resetParameters(props.light_id);
+    // resetParameters(props.light_id);
     setParameters(props.default_params);
   }
 
@@ -41,7 +42,7 @@ const AnimationCard = (props: any) => {
   const handleCardClicked = (e: any) => {
     e.stopPropagation();
     setCardClickAnimation(true);
-    selectAnimation(props.light_id);
+    dispatch(selectAnimation(props.light_id));
   };
 
   const cardClassName = `${cardClickAnimation ? 'animate-click' : ''} relative aspect-4/3 rounded-lg overflow-hidden shadow-md hover:shadow-lg`;

--- a/webapp/frontend/src/app/AnimationCard.tsx
+++ b/webapp/frontend/src/app/AnimationCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
-import { selectAnimation } from '@/reducers/rootReducer';
+import { selectAnimation, updateParameters, resetParameters } from '@/reducers/animationsReducer';
 import { useAppDispatch } from '@/hooks/hooks';
 
 const AnimationCard = (props: any) => {
@@ -20,12 +20,12 @@ const AnimationCard = (props: any) => {
   const handleParameterEdit = (e: any) => {
     e.preventDefault();
     setEditing(false);
-    // updateParameters(props.light_id, parameters);
+    dispatch(updateParameters({animationId: props.light_id, newParams: parameters}));
   };
 
   const handleResetButtonClick = (e: any) => {
     e.stopPropagation();
-    // resetParameters(props.light_id);
+    dispatch(resetParameters(props.light_id));
     setParameters(props.default_params);
   }
 

--- a/webapp/frontend/src/app/ErrorMessage.tsx
+++ b/webapp/frontend/src/app/ErrorMessage.tsx
@@ -1,24 +1,24 @@
 "use client";
 
-import { useBackend } from "@/hooks/backend";
+import { useAppDispatch, useAppSelector } from "@/hooks/hooks";
+import { clearError, selectError } from "@/reducers/rootReducer";
 
 const ErrorMessage = (props: any) => {
-    const {status, clearStatus} = useBackend();
+  const dispatch = useAppDispatch();
+  const error = useAppSelector(selectError);
 
-    const {message, error} = status;
-
-    return (
-      <div className="z-10 fixed left-1/2 transform -translate-x-1/2 shadow-lg bg-red-400 rounded-lg p-4 max-w-screen-sm" hidden={!error}>
-        <div className="absolute top-0 right-0">
-          <button onClick={clearStatus}>
-            <svg className="fill-current w-6 h-6 text-slate-800" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M5.293 5.293a1 1 0 0 1 1.414 0L10 8.586l3.293-3.293a1 1 0 1 1 1.414 1.414L11.414 10l3.293 3.293a1 1 0 0 1-1.414 1.414L10 11.414l-3.293 3.293a1 1 0 0 1-1.414-1.414L8.586 10 5.293 6.707a1 1 0 0 1 0-1.414z" clipRule="evenodd" />
-            </svg>
-          </button>
-        </div>
-        <p className="text-slate-800 font-semibold">{message}</p>
+  return (
+    <div className="z-10 fixed left-1/2 transform -translate-x-1/2 shadow-lg bg-red-400 rounded-lg p-4 max-w-screen-sm" hidden={!error}>
+      <div className="absolute top-0 right-0">
+        <button onClick={() => dispatch(clearError)}>
+          <svg className="fill-current w-6 h-6 text-slate-800" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M5.293 5.293a1 1 0 0 1 1.414 0L10 8.586l3.293-3.293a1 1 0 1 1 1.414 1.414L11.414 10l3.293 3.293a1 1 0 0 1-1.414 1.414L10 11.414l-3.293 3.293a1 1 0 0 1-1.414-1.414L8.586 10 5.293 6.707a1 1 0 0 1 0-1.414z" clipRule="evenodd" />
+          </svg>
+        </button>
       </div>
-    )
+      <p className="text-slate-800 font-semibold">{error}</p>
+    </div>
+  )
 }
 
 export default ErrorMessage;

--- a/webapp/frontend/src/app/ErrorMessage.tsx
+++ b/webapp/frontend/src/app/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAppDispatch, useAppSelector } from "@/hooks/hooks";
-import { clearError, selectError } from "@/reducers/rootReducer";
+import { clearError, selectError } from "@/reducers/animationsReducer";
 
 const ErrorMessage = (props: any) => {
   const dispatch = useAppDispatch();
@@ -10,7 +10,7 @@ const ErrorMessage = (props: any) => {
   return (
     <div className="z-10 fixed left-1/2 transform -translate-x-1/2 shadow-lg bg-red-400 rounded-lg p-4 max-w-screen-sm" hidden={!error}>
       <div className="absolute top-0 right-0">
-        <button onClick={() => dispatch(clearError)}>
+        <button onClick={() => dispatch(clearError())}>
           <svg className="fill-current w-6 h-6 text-slate-800" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
             <path fillRule="evenodd" d="M5.293 5.293a1 1 0 0 1 1.414 0L10 8.586l3.293-3.293a1 1 0 1 1 1.414 1.414L11.414 10l3.293 3.293a1 1 0 0 1-1.414 1.414L10 11.414l-3.293 3.293a1 1 0 0 1-1.414-1.414L8.586 10 5.293 6.707a1 1 0 0 1 0-1.414z" clipRule="evenodd" />
           </svg>

--- a/webapp/frontend/src/app/app.tsx
+++ b/webapp/frontend/src/app/app.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useBackend } from "@/hooks/backend";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import AnimationCard from "./AnimationCard";
 import ErrorMessage from "./ErrorMessage";
-import { getAnimations, getSelectedAnimation, selectAllAnimations, selectSelectedAnimation, selectStatus } from "@/reducers/rootReducer";
+import { getAnimations, getSelectedAnimation, selectAllAnimations, selectSelectedAnimation, selectStatus } from "@/reducers/animationsReducer";
 import { useAppDispatch, useAppSelector } from "@/hooks/hooks";
-import { useSelectedLayoutSegment } from "next/navigation";
 
 interface LightPattern {
   id: number,

--- a/webapp/frontend/src/app/app.tsx
+++ b/webapp/frontend/src/app/app.tsx
@@ -25,40 +25,41 @@ interface ErrorState {
 }
 
 export const App = () => {
-  const {animations, selectedAnimation} = useBackend();
+  return <div></div>;
+  // const {animations, selectedAnimation} = useBackend();
 
-  let selectionText, selectionDescription;
-  if (selectedAnimation === null || Object.keys(animations).length == 0) {
-    selectionText = "None! Select one below.";
-    selectionDescription = "None! Select one below.";
-  } else {
-    selectionText = animations[selectedAnimation].title;
-    selectionDescription = animations[selectedAnimation].description;
-  }
-  const lightPatternList = Object.values(animations).sort((a, b) => a.position - b.position);
+  // let selectionText, selectionDescription;
+  // if (selectedAnimation === null || Object.keys(animations).length == 0) {
+  //   selectionText = "None! Select one below.";
+  //   selectionDescription = "None! Select one below.";
+  // } else {
+  //   selectionText = animations[selectedAnimation].title;
+  //   selectionDescription = animations[selectedAnimation].description;
+  // }
+  // const lightPatternList = Object.values(animations).sort((a, b) => a.position - b.position);
 
-  return (
-    <div className="bg-gray-200 p-4 pt-16">
-      <ErrorMessage />
-      <p className="text-lg text-center font-semibold text-slate-700">
-        Current Selection: {selectionText}
-      </p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4">
-        {lightPatternList.map((choice) => 
-            <AnimationCard 
-              selectionCallback={() => {}}
-              resetParametersCallback={() => {}}
-              editParametersCallback={() => {}}
-              params={choice.parameters_json}
-              default_params={choice.default_parameters_json}
-              name={choice.title} 
-              image_url={choice.image_url} 
-              key={choice.id} 
-              light_id={choice.id} 
-              light_name={choice.animation_id}
-            />
-          )}
-      </div>
-  </div>
-  );
+  // return (
+  //   <div className="bg-gray-200 p-4 pt-16">
+  //     <ErrorMessage />
+  //     <p className="text-lg text-center font-semibold text-slate-700">
+  //       Current Selection: {selectionText}
+  //     </p>
+  //     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4">
+  //       {lightPatternList.map((choice) => 
+  //           <AnimationCard 
+  //             selectionCallback={() => {}}
+  //             resetParametersCallback={() => {}}
+  //             editParametersCallback={() => {}}
+  //             params={choice.parameters_json}
+  //             default_params={choice.default_parameters_json}
+  //             name={choice.title} 
+  //             image_url={choice.image_url} 
+  //             key={choice.id} 
+  //             light_id={choice.id} 
+  //             light_name={choice.animation_id}
+  //           />
+  //         )}
+  //     </div>
+  // </div>
+  // );
 }

--- a/webapp/frontend/src/app/app.tsx
+++ b/webapp/frontend/src/app/app.tsx
@@ -51,10 +51,19 @@ export const App = () => {
   const lightPatternList = Object.values(animations).sort((a, b) => a.position - b.position);
 
   return (
-    <div className="bg-gray-200 p-4 pt-16">
+    <div className="bg-gray-200 p-4">
       <ErrorMessage />
+      <p className="leading-tight text-center max-w-fit mx-auto text-5xl font-extrabold text-transparent bg-clip-text text-center bg-gradient-to-r from-rose-600 to-green-600">
+          Plaid Family Lights
+      </p>
+      <p className="text-2xl text-center text-slate-800 font-bold">
+        Select an animation
+      </p>
       <p className="text-lg text-center font-semibold text-slate-700">
         Current Selection: {selectionText}
+      </p>
+      <p className="pb-4 text-md text-center text-slate-700">
+          {selectionDescription}
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4">
         {lightPatternList.map((choice) => 

--- a/webapp/frontend/src/app/app.tsx
+++ b/webapp/frontend/src/app/app.tsx
@@ -4,6 +4,9 @@ import { useBackend } from "@/hooks/backend";
 import { useState, useEffect } from "react";
 import AnimationCard from "./AnimationCard";
 import ErrorMessage from "./ErrorMessage";
+import { getAnimations, getSelectedAnimation, selectAllAnimations, selectSelectedAnimation, selectStatus } from "@/reducers/rootReducer";
+import { useAppDispatch, useAppSelector } from "@/hooks/hooks";
+import { useSelectedLayoutSegment } from "next/navigation";
 
 interface LightPattern {
   id: number,
@@ -25,41 +28,52 @@ interface ErrorState {
 }
 
 export const App = () => {
-  return <div></div>;
-  // const {animations, selectedAnimation} = useBackend();
 
-  // let selectionText, selectionDescription;
-  // if (selectedAnimation === null || Object.keys(animations).length == 0) {
-  //   selectionText = "None! Select one below.";
-  //   selectionDescription = "None! Select one below.";
-  // } else {
-  //   selectionText = animations[selectedAnimation].title;
-  //   selectionDescription = animations[selectedAnimation].description;
-  // }
-  // const lightPatternList = Object.values(animations).sort((a, b) => a.position - b.position);
+  const status = useAppSelector(selectStatus);
+  const dispatch = useAppDispatch();
 
-  // return (
-  //   <div className="bg-gray-200 p-4 pt-16">
-  //     <ErrorMessage />
-  //     <p className="text-lg text-center font-semibold text-slate-700">
-  //       Current Selection: {selectionText}
-  //     </p>
-  //     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4">
-  //       {lightPatternList.map((choice) => 
-  //           <AnimationCard 
-  //             selectionCallback={() => {}}
-  //             resetParametersCallback={() => {}}
-  //             editParametersCallback={() => {}}
-  //             params={choice.parameters_json}
-  //             default_params={choice.default_parameters_json}
-  //             name={choice.title} 
-  //             image_url={choice.image_url} 
-  //             key={choice.id} 
-  //             light_id={choice.id} 
-  //             light_name={choice.animation_id}
-  //           />
-  //         )}
-  //     </div>
-  // </div>
-  // );
+  useEffect(() => {
+    if(status == 'idle') {
+      dispatch(getAnimations());
+      dispatch(getSelectedAnimation());
+    }
+  }, [dispatch, status]);
+
+  const animations = useAppSelector(selectAllAnimations);
+  const selectedAnimation = useAppSelector(selectSelectedAnimation);
+
+  let selectionText, selectionDescription;
+  if (selectedAnimation === 0 || Object.keys(animations).length == 0) {
+    selectionText = "None! Select one below.";
+    selectionDescription = "None! Select one below.";
+  } else {
+    selectionText = animations[selectedAnimation].title;
+    selectionDescription = animations[selectedAnimation].description;
+  }
+  const lightPatternList = Object.values(animations).sort((a, b) => a.position - b.position);
+
+  return (
+    <div className="bg-gray-200 p-4 pt-16">
+      <ErrorMessage />
+      <p className="text-lg text-center font-semibold text-slate-700">
+        Current Selection: {selectionText}
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4">
+        {lightPatternList.map((choice) => 
+            <AnimationCard 
+              selectionCallback={() => {}}
+              resetParametersCallback={() => {}}
+              editParametersCallback={() => {}}
+              params={choice.parameters_json}
+              default_params={choice.default_parameters_json}
+              name={choice.title} 
+              image_url={choice.image_url} 
+              key={choice.id} 
+              light_id={choice.id} 
+              light_name={choice.animation_id}
+            />
+          )}
+      </div>
+  </div>
+  );
 }

--- a/webapp/frontend/src/app/page.tsx
+++ b/webapp/frontend/src/app/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { BackendContextProvider } from "@/context/backend";
 import { useSearchParams } from "next/navigation";
 import { App } from './app';
-import { store } from "@/lib/store";
+import { createStore } from "@/lib/store";
 import { Provider } from 'react-redux'
 
 const Home = () => {
   const password = useSearchParams().get('p') || "";
+  const store = createStore(password);
   
   return (
       <Provider store={store}>

--- a/webapp/frontend/src/app/page.tsx
+++ b/webapp/frontend/src/app/page.tsx
@@ -3,14 +3,16 @@
 import { BackendContextProvider } from "@/context/backend";
 import { useSearchParams } from "next/navigation";
 import { App } from './app';
+import { store } from "@/lib/store";
+import { Provider } from 'react-redux'
 
 const Home = () => {
   const password = useSearchParams().get('p') || "";
   
   return (
-    <BackendContextProvider apiAuth={password}>
-      <App />
-    </BackendContextProvider>
+      <Provider store={store}>
+        <App />
+      </Provider>
   );
 }
 

--- a/webapp/frontend/src/context/backend.tsx
+++ b/webapp/frontend/src/context/backend.tsx
@@ -113,7 +113,6 @@ export function BackendContextProvider({ children, apiAuth } : React.PropsWithCh
     async (animation_id: number) => {
       const resetPayload = {
         light_pattern_id: animation_id,
-        light_pattern_name: animations[animation_id].animation_id,
       };
       const res = await postAPI("/api/options/reset_parameters/", JSON.stringify(resetPayload), apiAuth)
       if(!res.ok) {
@@ -127,7 +126,6 @@ export function BackendContextProvider({ children, apiAuth } : React.PropsWithCh
     async (animation_id: number, new_params: {}) => {
       const updatePayload = {
         light_pattern_id: animation_id,
-        light_pattern_name: animations[animation_id].animation_id,
         parameters: new_params,
       };
       const res = await postAPI("/api/options/update_parameters/", JSON.stringify(updatePayload), apiAuth);

--- a/webapp/frontend/src/hooks/hooks.tsx
+++ b/webapp/frontend/src/hooks/hooks.tsx
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import type { RootState, AppDispatch } from '@/lib/store'
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/webapp/frontend/src/lib/store.tsx
+++ b/webapp/frontend/src/lib/store.tsx
@@ -1,16 +1,28 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { createAnimationSlice } from '@/reducers/rootReducer'
+import { animationSlice } from '@/reducers/rootReducer'
+import axios from 'axios';
 
 export const createStore = (apiAuth: string) => {
-  const animationSlice = createAnimationSlice(apiAuth);
+
+  const instance = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_BASE_URL
+  });
+  // instance.defaults.xsrfHeaderName = "X-CSRFTOKEN";
+  // instance.defaults.xsrfCookieName = "csrftoken";
+  instance.defaults.headers.common['API_AUTH'] = apiAuth;
+
   return configureStore({
     reducer: {
       animation: animationSlice.reducer
-    }
+    },
+    middleware: (getDefaultMiddleware) => 
+      getDefaultMiddleware(
+        {
+          thunk: {extraArgument: instance},
+        }
+      )
   });
 };
 
-// Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<ReturnType<typeof createStore>['getState']>;
-// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
 export type AppDispatch = ReturnType<typeof createStore>['dispatch'];

--- a/webapp/frontend/src/lib/store.tsx
+++ b/webapp/frontend/src/lib/store.tsx
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { animationReducer } from '@/reducers/rootReducer'
+
+export const store = configureStore({
+  reducer: {
+    animation: animationReducer,
+  }
+})
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>
+// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+export type AppDispatch = typeof store.dispatch

--- a/webapp/frontend/src/lib/store.tsx
+++ b/webapp/frontend/src/lib/store.tsx
@@ -1,13 +1,16 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { animationReducer } from '@/reducers/rootReducer'
+import { createAnimationSlice } from '@/reducers/rootReducer'
 
-export const store = configureStore({
-  reducer: {
-    animation: animationReducer,
-  }
-})
+export const createStore = (apiAuth: string) => {
+  const animationSlice = createAnimationSlice(apiAuth);
+  return configureStore({
+    reducer: {
+      animation: animationSlice.reducer
+    }
+  });
+};
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
-export type RootState = ReturnType<typeof store.getState>
+export type RootState = ReturnType<ReturnType<typeof createStore>['getState']>;
 // Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
-export type AppDispatch = typeof store.dispatch
+export type AppDispatch = ReturnType<typeof createStore>['dispatch'];

--- a/webapp/frontend/src/lib/store.tsx
+++ b/webapp/frontend/src/lib/store.tsx
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { animationSlice } from '@/reducers/rootReducer'
+import { animationSlice } from '@/reducers/animationsReducer';
 import axios from 'axios';
 
 export const createStore = (apiAuth: string) => {

--- a/webapp/frontend/src/reducers/animationsReducer.tsx
+++ b/webapp/frontend/src/reducers/animationsReducer.tsx
@@ -50,7 +50,7 @@ export const selectAnimation = createAppAsyncThunk<number, number>(
     };
 
     return axiosInstance.post('/api/selections/', selectionPayload)
-      .then(() => animationId)
+      .then(() => animationId);
   }
 );
 
@@ -65,18 +65,43 @@ export const getAnimations = createAppAsyncThunk<AnimationsMap>(
 
 export const getSelectedAnimation = createAppAsyncThunk<number>(
   'animations/getSelectedAnimation',
-  async (animationId, thunkAPI) => {
+  async (_, thunkAPI) => {
     const axiosInstance = thunkAPI.extra;
     const res = await axiosInstance.get('/api/selections/last/');
     return res.data.light_pattern_id;
   }
 );
 
+export const resetParameters = createAppAsyncThunk<void, number>(
+  'animations/resetParameters',
+  (animationId, thunkAPI) => {
+    const axiosInstance = thunkAPI.extra;
+    const resetPayload = {
+      light_pattern_id: animationId,
+    };
+
+    return axiosInstance.post('/api/options/reset_parameters/', resetPayload);
+  }
+)
+
+export const updateParameters = createAppAsyncThunk<void, {animationId: number, newParams: {}}>(
+  'animations/updateParameters',
+  ({animationId, newParams}, thunkAPI) => {
+    const axiosInstance = thunkAPI.extra;
+    const updatePayload = {
+      light_pattern_id: animationId,
+      parameters: newParams,
+    };
+
+    return axiosInstance.post('/api/options/update_parameters/', updatePayload);
+  }
+)
+
 export const animationSlice = createSlice({
   name: 'animation',
   initialState: initialState,
   reducers: {
-    clearError: (state, _) => {
+    clearError: (state) => {
       state.error = null;
     }
   },

--- a/webapp/frontend/src/reducers/rootReducer.tsx
+++ b/webapp/frontend/src/reducers/rootReducer.tsx
@@ -1,0 +1,38 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export type Animation = {
+  id: number,
+  animation_id: number,
+  image_url: string,
+  parameters_json: string,
+  default_parameters_json: string,
+  title: string,
+  description: string,
+  position: number,
+};
+
+export type AnimationsState = {
+  animations: {
+    [index: number]: Animation,
+  },
+  selectedAnimation: number,
+};
+
+const initialState: AnimationsState = {
+  animations: {},
+  selectedAnimation: 0, 
+}
+
+export const animationSlice = createSlice({
+  name: 'animation',
+  initialState: initialState,
+  reducers: {
+    selectAnimation: (state, action) => {
+      state.selectedAnimation = action.payload
+    }
+  }
+});
+
+export const { selectAnimation } = animationSlice.actions
+
+export const animationReducer = animationSlice.reducer

--- a/webapp/frontend/src/reducers/rootReducer.tsx
+++ b/webapp/frontend/src/reducers/rootReducer.tsx
@@ -1,4 +1,6 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice, isRejected } from "@reduxjs/toolkit";
+import { AxiosInstance } from "axios";
+import { AppDispatch, RootState } from "@/lib/store";
 
 export type Animation = {
   id: number,
@@ -11,27 +13,108 @@ export type Animation = {
   position: number,
 };
 
+export type AnimationsMap = {
+  [index: number]: Animation,
+}
+
 export type AnimationsState = {
-  animations: {
-    [index: number]: Animation,
-  },
+  animations: AnimationsMap,
   selectedAnimation: number,
-  apiAuth: string,
+  status: 'idle' | 'loading' | 'succeeded' | 'failed',
+  error: string | null,
 };
 
-export const createAnimationSlice = (apiAuth: string) => {
-  const initialState: AnimationsState = {
-    animations: {},
-    selectedAnimation: 0,
-    apiAuth: apiAuth,
-  };
-  return createSlice({
-    name: 'animation',
-    initialState: initialState,
-    reducers: {
-      selectAnimation: (state, action) => {
-        state.selectedAnimation = action.payload
-      }
-    }
-  });
+const initialState: AnimationsState = {
+  animations: {},
+  selectedAnimation: 0,
+  status: 'idle',
+  error: null,
 };
+
+const createAppAsyncThunk = createAsyncThunk.withTypes<{
+  state: RootState,
+  dispatch: AppDispatch,
+  rejectValue: string,
+  extra: AxiosInstance
+}>();
+
+export const selectAnimation = createAppAsyncThunk<number, number>(
+  'animations/selectAnimation', 
+  (animationId, thunkAPI) => {
+    const axiosInstance = thunkAPI.extra;
+    const date = new Date();
+    date.setTime(date.getTime() - date.getTimezoneOffset() * 60 * 1000);
+    const selectionPayload = {
+      light_pattern_id: animationId,
+      timestamp: date.toISOString(),
+    };
+
+    return axiosInstance.post('/api/selections/', selectionPayload)
+      .then(() => animationId)
+  }
+);
+
+export const getAnimations = createAppAsyncThunk<AnimationsMap>(
+  'animations/getAnimations',
+  async (_, thunkAPI) => {
+    const axiosInstance = thunkAPI.extra;
+    const res = await axiosInstance.get('/api/options/');
+    return Object.fromEntries(res.data.map((a: Animation) => [a.id, a]));
+  }
+);
+
+export const getSelectedAnimation = createAppAsyncThunk<number>(
+  'animations/getSelectedAnimation',
+  async (animationId, thunkAPI) => {
+    const axiosInstance = thunkAPI.extra;
+    const res = await axiosInstance.get('/api/selections/last/');
+    return res.data.light_pattern_id;
+  }
+);
+
+export const animationSlice = createSlice({
+  name: 'animation',
+  initialState: initialState,
+  reducers: {
+    clearError: (state, _) => {
+      state.error = null;
+    }
+  },
+  extraReducers(builder) {
+    builder
+      .addCase(selectAnimation.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        state.selectedAnimation = action.payload;
+      })
+      .addCase(selectAnimation.rejected, (state, action) => {
+        state.status = 'failed'
+        state.error = action.error.message || null;
+      })
+      .addCase(getAnimations.pending, (state, _) => {
+        state.status = 'loading';
+      })
+      .addCase(getAnimations.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        state.animations = action.payload;
+      })
+      .addCase(getSelectedAnimation.fulfilled, (state, action) => {
+        state.selectedAnimation = action.payload;
+      })
+      .addMatcher(isRejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.error.message || null;
+      })
+  }
+});
+
+export const { clearError } = animationSlice.actions;
+
+export default animationSlice.reducer;
+
+export const selectAllAnimations = (state: RootState) => state.animation.animations;
+
+export const selectSelectedAnimation = (state: RootState) => state.animation.selectedAnimation;
+
+export const selectStatus = (state: RootState) => state.animation.status;
+
+export const selectError = (state: RootState) => state.animation.error;

--- a/webapp/frontend/src/reducers/rootReducer.tsx
+++ b/webapp/frontend/src/reducers/rootReducer.tsx
@@ -16,23 +16,22 @@ export type AnimationsState = {
     [index: number]: Animation,
   },
   selectedAnimation: number,
+  apiAuth: string,
 };
 
-const initialState: AnimationsState = {
-  animations: {},
-  selectedAnimation: 0, 
-}
-
-export const animationSlice = createSlice({
-  name: 'animation',
-  initialState: initialState,
-  reducers: {
-    selectAnimation: (state, action) => {
-      state.selectedAnimation = action.payload
+export const createAnimationSlice = (apiAuth: string) => {
+  const initialState: AnimationsState = {
+    animations: {},
+    selectedAnimation: 0,
+    apiAuth: apiAuth,
+  };
+  return createSlice({
+    name: 'animation',
+    initialState: initialState,
+    reducers: {
+      selectAnimation: (state, action) => {
+        state.selectedAnimation = action.payload
+      }
     }
-  }
-});
-
-export const { selectAnimation } = animationSlice.actions
-
-export const animationReducer = animationSlice.reducer
+  });
+};


### PR DESCRIPTION
This diff adds Redux for managing global state

At the moment, our app has two pieces of state that live at the root: a list of animations and the currently selected animation. Our children components `ErrorMessage` and `AnimationCard` need the ability to interact with this state, which we currently provide using custom props and callbacks. While this approach does work, it's easy to see how this can quickly devolve into prop drilling, especially as the app increases in complexity. Redux elegantly solves this problem of sharing state between components by maintaining a single state storage location that components anywhere in the app can read from and update freely. Components can independently pick which state they want to pay attention to, and dispatch actions to update this state. With Redux, we can freely modularize our app into many simple components without the fear of maintaining long prop chains for interacting with the global state.